### PR TITLE
Features/af 234 apply for membership

### DIFF
--- a/src/main/java/com/aline/core/dto/response/ApplicantResponse.java
+++ b/src/main/java/com/aline/core/dto/response/ApplicantResponse.java
@@ -1,7 +1,6 @@
 package com.aline.core.dto.response;
 
 import com.aline.core.model.Applicant;
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/aline/core/dto/response/ApplicantResponse.java
+++ b/src/main/java/com/aline/core/dto/response/ApplicantResponse.java
@@ -2,6 +2,7 @@ package com.aline.core.dto.response;
 
 import com.aline.core.model.Applicant;
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -52,7 +53,7 @@ public class ApplicantResponse {
     private LocalDateTime lastModifiedAt;
     private LocalDateTime createdAt;
 
-    @JsonBackReference
+    @JsonIgnore
     private LinkedHashSet<ApplicantResponse> applications;
 
     @Override

--- a/src/main/java/com/aline/core/dto/response/ApplicationResponse.java
+++ b/src/main/java/com/aline/core/dto/response/ApplicationResponse.java
@@ -38,7 +38,6 @@ public class ApplicationResponse implements Serializable {
     /**
      * All applicants that have applied under the referenced application
      */
-    @JsonManagedReference
     private LinkedHashSet<ApplicantResponse> applicants;
 
     /**

--- a/src/main/java/com/aline/core/dto/response/ApplicationResponse.java
+++ b/src/main/java/com/aline/core/dto/response/ApplicationResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -15,7 +16,7 @@ import java.util.Set;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class ApplicationResponse {
+public class ApplicationResponse implements Serializable {
 
     /**
      * Application ID

--- a/src/main/java/com/aline/core/dto/response/ApplicationResponse.java
+++ b/src/main/java/com/aline/core/dto/response/ApplicationResponse.java
@@ -1,7 +1,6 @@
 package com.aline.core.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/aline/core/dto/response/PaginatedResponse.java
+++ b/src/main/java/com/aline/core/dto/response/PaginatedResponse.java
@@ -1,0 +1,40 @@
+package com.aline.core.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PaginatedResponse<T> extends PageImpl<T> {
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public PaginatedResponse(@JsonProperty("content") List<T> content,
+                             @JsonProperty("number") int number,
+                             @JsonProperty("size") int size,
+                             @JsonProperty("totalElements") Long totalElements,
+                             @JsonProperty("pageable") JsonNode pageable,
+                             @JsonProperty("last") boolean last,
+                             @JsonProperty("totalPages") int totalPages,
+                             @JsonProperty("sort") JsonNode sort,
+                             @JsonProperty("first") boolean first,
+                             @JsonProperty("empty") boolean empty) {
+
+        super(content, PageRequest.of(number, size), totalElements);
+    }
+
+    public PaginatedResponse(List<T> content, Pageable pageable, long total) {
+        super(content, pageable, total);
+    }
+
+    public PaginatedResponse(List<T> content) {
+        super(content);
+    }
+
+    public PaginatedResponse() {
+        super(new ArrayList<>());
+    }
+}


### PR DESCRIPTION
Update ApplicantResponse to no longer use backreference and instead use jsonignore annotation.

You cannot use jsonbackreference on a collection.

Add PaginatedResponse generic object.

This is what will be used to send a paginated response of your DTO.

